### PR TITLE
Fix calculation of report begin date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+/*.iml
+/.idea
+
+### Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.509</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>build-metrics</artifactId>

--- a/src/main/java/jenkins/plugins/build_metrics/BuildMetricsPluginSearchFactory.java
+++ b/src/main/java/jenkins/plugins/build_metrics/BuildMetricsPluginSearchFactory.java
@@ -82,7 +82,7 @@ public class BuildMetricsPluginSearchFactory {
 	      iUnits = Calendar.YEAR;
 		}
 		Calendar tmpCal = Calendar.getInstance();
-		tmpCal.roll(iUnits, iRange);
+		tmpCal.add(iUnits, iRange);
 		return new Long(tmpCal.getTimeInMillis());
 	}
 	

--- a/src/test/java/jenkins/plugins/build_metrics/stats/StatsFactoryTest.java
+++ b/src/test/java/jenkins/plugins/build_metrics/stats/StatsFactoryTest.java
@@ -17,10 +17,10 @@ public class StatsFactoryTest {
 		jbsr.add(createJobResult("build job 1", true));
 		jbsr.add(createJobResult("build job 1", false));
 		StatsFactory sf = StatsFactory.generateStats(jbsr);
-		assertEquals("StatsFactory.failureRate", 50.00, sf.getFailureRate());
+		assertEquals("StatsFactory.failureRate", 50.00, sf.getFailureRate(), 0);
 		
 		for(StatsModel stat: sf.getStats()){
-		  assertEquals("StatsModel.failureRate", 50.00, stat.getFailureRate());
+		  assertEquals("StatsModel.failureRate", 50.00, stat.getFailureRate(), 0);
 	  }
 	}
 	

--- a/src/test/java/jenkins/plugins/build_metrics/stats/StatsMathTest.java
+++ b/src/test/java/jenkins/plugins/build_metrics/stats/StatsMathTest.java
@@ -7,16 +7,16 @@ public class StatsMathTest {
 	@Test
 	public void testRoundTwoDecimals(){
 		double d1 = 1.2345;
-		assertEquals(d1 + " rounded to two decimal places", 1.23, StatsMath.roundTwoDecimals(d1));
+		assertEquals(d1 + " rounded to two decimal places", 1.23, StatsMath.roundTwoDecimals(d1), 0);
 	}
 	
 	@Test
 	public void testPercent(){
 		double subVal = 2;
 		double totalVal = 3;
-		assertEquals("zero total", 0.00, StatsMath.getPercent(subVal, 0));
-		assertEquals("2/3", 66.67, StatsMath.getPercent(subVal, totalVal));
-		assertEquals("1/1", 100.00, StatsMath.getPercent(1, 1));
-		assertEquals("3/2", 150.00, StatsMath.getPercent(3, 2));
+		assertEquals("zero total", 0.00, StatsMath.getPercent(subVal, 0), 0);
+		assertEquals("2/3", 66.67, StatsMath.getPercent(subVal, totalVal), 0);
+		assertEquals("1/1", 100.00, StatsMath.getPercent(1, 1), 0);
+		assertEquals("3/2", 150.00, StatsMath.getPercent(3, 2), 0);
 	}
 }


### PR DESCRIPTION
Currently, computation is done using `Calendar.roll()` which is wrong.
`roll()` only changes a specific unit and doesn't update larger fields.
For example, rolling back 2 week on the first week of a month sets
the calendar week to the last week of the month, which is in the future.
Obviously, when the begin date is in the future, there's nothing in the
report.

Using `Calendar.add()` with a negative value subtracts the right amount
of time from the current time.

I guess it never really worked before.

@reviewbybees 