### PR TITLE
Updated for Jenkins 2 folders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>3.12</version>
     <relativePath />
   </parent>
 
@@ -12,13 +12,8 @@
   <packaging>hpi</packaging>
   
   <properties>
-    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.609.1</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-    <java.level>7</java.level>
-    <!-- Jenkins Test Harness version you use to test the plugin. -->
-    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <scm>

--- a/src/main/java/jenkins/plugins/build_metrics/BuildMetricsBuild.java
+++ b/src/main/java/jenkins/plugins/build_metrics/BuildMetricsBuild.java
@@ -16,6 +16,8 @@ public class BuildMetricsBuild {
 	private long duration;
 	private String status;
 	private String description;
+	private String jobUrl;
+	private String buildUrl;
 	
 	public BuildMetricsBuild(int buildNumber, String jobName, String nodeName, String userName, Calendar buildDate, long duration, String status, String description){
 		this.buildNumber = buildNumber;
@@ -26,6 +28,8 @@ public class BuildMetricsBuild {
 		this.duration = duration;
 		this.status = status;
 		this.description = description;
+                this.jobUrl = "job/" + jobName.replaceAll("/","/job/");
+                this.buildUrl = this.jobUrl + "/" + String.valueOf(buildNumber);
 	}
 	
 	public int getBuildNumber() {
@@ -80,4 +84,10 @@ public class BuildMetricsBuild {
 	public void setDescription(String description){
 		this.description = description;
 	}
+        public String getJobUrl() {
+            return this.jobUrl;
+        }
+        public String getBuildUrl() {
+            return this.buildUrl;
+        }
 }

--- a/src/main/java/jenkins/plugins/build_metrics/stats/StatsModel.java
+++ b/src/main/java/jenkins/plugins/build_metrics/stats/StatsModel.java
@@ -13,6 +13,7 @@ public class StatsModel implements Comparable{
 	private int nobuilds;
 	private int totalBuilds;
 	private String space;
+	private String jobUrl;
 	
 	public StatsModel(String jobName){
 	  this.jobName = jobName;
@@ -23,6 +24,7 @@ public class StatsModel implements Comparable{
 	  this.nobuilds = 0;
 	  this.totalBuilds = 0;
 	  this.space="&nbsp;";
+          this.jobUrl = "job/" + jobName.replaceAll("/","/job/");
 	}
 	
 	public String getJobName(){
@@ -102,6 +104,11 @@ public class StatsModel implements Comparable{
 	public int compareTo(StatsModel sm){
 	  return this.jobName.toUpperCase().compareTo(sm.getJobName().toUpperCase());
 	}
+
+        @Exported
+        public String getJobUrl() {
+          return this.jobUrl;
+        }
 
 	@Override
 	public int hashCode() {

--- a/src/main/resources/jenkins/plugins/build_metrics/BuildMetricsPlugin/BuildStats.jelly
+++ b/src/main/resources/jenkins/plugins/build_metrics/BuildMetricsPlugin/BuildStats.jelly
@@ -33,8 +33,8 @@
           <th>${%Failure Rate}</th>
           </tr>
 			    <j:forEach var="stat" items="${buildStats.stats}">
-			    	<tr class="build-row">
-			    		<td class="pane"><a href="${rootURL}/job/${stat.jobName}/">${stat.jobName}</a></td>
+            <tr class="build-row">
+              <td class="pane"><a href="${rootURL}/${stat.jobUrl}">${stat.jobName}</a></td>
               <td class="pane">${stat.successes}</td>
               <td class="pane">${stat.failures}</td>
               <td class="pane">${stat.unstables}</td>
@@ -78,12 +78,14 @@
             <j:forEach var="build" items="${failedBuilds}">
               <tr class="build-row">
                 <td class="pane">${build.status}</td>
-                <td class="pane"><a href="${rootURL}/job/${build.jobName}/">${build.jobName}</a></td>
+                <td class="pane"><a href="${rootURL}/${build.jobUrl}/">${build.jobName}</a></td>
                 <td class="pane">
-                  <a href="${rootURL}/job/${build.jobName}/${build.buildNumber}/console"><img src="${rootURL}/plugin/global-build-stats/icons/terminal.gif" /></a>
-                  <a href="${rootURL}/job/${build.jobName}/${build.buildNumber}/">#${build.buildNumber}</a>
+                     <a href="${rootURL}/${build.buildUrl}/console"><img src="${rootURL}/plugin/global-build-stats/icons/terminal.gif" /></a>
+                     <a href="${rootURL}/${build.buildUrl}/">#${build.buildNumber}</a>
                 </td>
-                <td class="pane"><a href="${rootURL}/job/${build.jobName}/${build.buildNumber}/">${build.buildDateString}</a></td>
+                <td class="pane">
+                     <a href="${rootURL}/${build.buildUrl}/">${build.buildDateString}</a>
+                </td>
                 <td class="pane">${build.duration}</td>
                 <td class="pane">${build.nodeName}</td>
                 <td class="pane">${build.userName}</td>

--- a/src/test/java/jenkins/plugins/build_metrics/stats/StatsModelTest.java
+++ b/src/test/java/jenkins/plugins/build_metrics/stats/StatsModelTest.java
@@ -1,6 +1,7 @@
 package jenkins.plugins.build_metrics.stats;
 
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 public class StatsModelTest {
 	@Test
@@ -28,4 +29,13 @@ public class StatsModelTest {
 		assert 5 == sm.getTotalBuilds();
 		assert ((4.00 / 5.00) * 100.00) == sm.getFailureRate();
 	}
+
+    @Test
+    public void testFolders() {
+        String expectedJobUrl = "job/folder1/job/folder2/job/test";
+        String expectedJobName = "folder1/folder2/test";
+        StatsModel sm = new StatsModel(expectedJobName);
+        assertEquals(expectedJobName, sm.getJobName());
+        assertEquals(expectedJobUrl, sm.getJobUrl());
+    }
 }


### PR DESCRIPTION
Resolves issue of broken links to jobs and builds in Jenkins 2. Verified with the global-build-stats plugin version 1.5, which uses full project names.